### PR TITLE
Upgrade bootstrap-sass to latest version of the 2.3 branch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+sudo: false
 language: ruby
 rvm:
   - 2.1.6

--- a/Gemfile
+++ b/Gemfile
@@ -11,7 +11,8 @@ gemspec
 
 group :development, :test do
   gem 'capybara'
-  gem 'guard-rspec'
+  gem 'guard', '~> 1.8'
+  gem 'guard-rspec', '~> 3.1'
 end
 
 # Declare any dependencies that are still in development here instead of in

--- a/bootstrap_haml_helpers.gemspec
+++ b/bootstrap_haml_helpers.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency "rails"
 
-  s.add_dependency "bootstrap-sass", "2.3.1.3"
+  s.add_dependency "bootstrap-sass", "2.3.2.2"
   s.add_dependency "haml"
   s.add_dependency "sass-rails"
   s.add_dependency "sass"

--- a/bootstrap_haml_helpers.gemspec
+++ b/bootstrap_haml_helpers.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
 
   s.files = Dir["{app,config,db,lib}/**/*"] + ["MIT-LICENSE", "Rakefile", "README.md"]
 
-  s.add_dependency "rails"
+  s.add_dependency "rails", ENV.fetch("RAILS_VERSION", '~> 4.0')
 
   s.add_dependency "bootstrap-sass", "2.3.2.2"
   s.add_dependency "haml"


### PR DESCRIPTION
The latest version of the 2.3 branch adds the glyphicons to the asset precompile list, which the version we're using doesn't do. This means a digested version of the glyphicons is not available in production and havoc is wrought.

@lumoslabs/platform @lumoslabs/rails 